### PR TITLE
fix: ping mingo to 6.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fast-sort": "^3.4.0",
-        "mingo": "^6.4.4"
+        "mingo": "6.4.6"
       },
       "devDependencies": {
         "@commitlint/cli": "17.7.2",
@@ -6351,9 +6351,9 @@
       }
     },
     "node_modules/mingo": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.4.7.tgz",
-      "integrity": "sha512-9CxaYNHl64KG/IPhIpTzNHajHB7HMj51bKy51Gdi3QzLOEbpK2mWzvs0U/3GCysytBycrkTjbNSP6GZ0rgh0hg=="
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.4.6.tgz",
+      "integrity": "sha512-SMp06Eo5iEthCPpKXgEZ6DTZKxknpTqj49YN6iHpapj9DKltBCv0RFu+0mBBjMU0SiHR9pYkurkk74+VFGTqxw=="
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
   },
   "dependencies": {
     "fast-sort": "^3.4.0",
-    "mingo": "^6.4.4"
+    "mingo": "6.4.6"
   }
 }


### PR DESCRIPTION
there is a bug introduced in 6.4.7 that breaks building in some environments