### PR TITLE
fix: rebuild indices after collection instantiation

### DIFF
--- a/packages/signaldb/__tests__/Collection.spec.ts
+++ b/packages/signaldb/__tests__/Collection.spec.ts
@@ -464,4 +464,14 @@ describe('Collection', () => {
       emitSpy.mockRestore()
     })
   })
+
+  describe('misc', () => {
+    it('should seed the collection with initial data from the memory adapter', () => {
+      const col = new Collection<{ id: string, name: string }>({
+        memory: createMemoryAdapter([{ id: '1', name: 'John' }]),
+      })
+
+      expect(col.findOne({ id: '1' })).toEqual({ id: '1', name: 'John' })
+    })
+  })
 })

--- a/packages/signaldb/src/Collection/index.ts
+++ b/packages/signaldb/src/Collection/index.ts
@@ -105,6 +105,7 @@ export default class Collection<T extends BaseItem<I> = BaseItem, I = any, U = T
       createExternalIndex('id', this.idIndex),
       ...(this.options.indices || []),
     ]
+    this.rebuildIndices()
     if (this.options.persistence) {
       const persistenceAdapter = this.options.persistence
       this.persistenceAdapter = persistenceAdapter
@@ -263,6 +264,11 @@ export default class Collection<T extends BaseItem<I> = BaseItem, I = any, U = T
   private rebuildIndicesOncePerTick = executeOncePerTick(this.rebuildAllIndices.bind(this))
 
   private rebuildAllIndices() {
+    this.idIndex.clear()
+    // eslint-disable-next-line array-callback-return
+    this.memory().map((item, index) => {
+      this.idIndex.set(serializeValue(item.id), new Set([index]))
+    })
     this.indexProviders.forEach(index => index.rebuild(this.memoryArray()))
     this.indicesOutdated = false
   }


### PR DESCRIPTION
this enables seeding the collection with a memory adapater that already has data in it
see https://github.com/maxnowack/signaldb/discussions/626#discussioncomment-8958776