### PR TITLE
Fix handling of empty changeset in localstorageapdater

### DIFF
--- a/packages/signaldb/__tests__/persistence.client.spec.ts
+++ b/packages/signaldb/__tests__/persistence.client.spec.ts
@@ -99,6 +99,17 @@ describe('Persistence', () => {
       expect(items).toEqual([{ id: '1', name: 'Johnny' }])
       expect((await persistence.load()).items).toEqual([{ id: '1', name: 'Johnny' }])
     }, { retry: 5 })
+
+    it('should not overwrite persisted data if items is undefined and changeSet is empty.', async () => {
+      const persistence = createLocalStorageAdapter(`test-${Math.floor(Math.random() * 1e17).toString(16)}`)
+      await persistence.save([], { added: [{ id: '1', name: 'John' }], removed: [], modified: [] })
+      const collection = new Collection({ persistence })
+      await waitForEvent(collection, 'persistence.init')
+      await persistence.save([], { added: [], removed: [], modified: [] })
+      const items = collection.find().fetch()
+      expect(items).toEqual([{ id: '1', name: 'John' }])
+      expect((await persistence.load()).items).toEqual([{ id: '1', name: 'John' }])
+    })
   })
 
   describe('OPFS', () => {

--- a/packages/signaldb/src/persistence/createLocalStorageAdapter.ts
+++ b/packages/signaldb/src/persistence/createLocalStorageAdapter.ts
@@ -14,10 +14,6 @@ export default function createLocalStorageAdapter<
       return Promise.resolve({ items })
     },
     async save(items, { added, modified, removed }) {
-      if (added.length === 0 && modified.length === 0 && removed.length === 0) {
-        localStorage.setItem(collectionId, JSON.stringify(items))
-        return Promise.resolve()
-      }
       const currentItems = getItems()
       added.forEach((item) => {
         currentItems.push(item)


### PR DESCRIPTION
This PR adds a test for saving an empty changeset.

It also removes a few lines with special handling of an empty changeset, potentially causing the persisted data to be wiped.

Fixes https://github.com/maxnowack/signaldb/issues/835