### PR TITLE
fix(sync-manager): last finished sync sorting should be by end

### DIFF
--- a/packages/signaldb/src/SyncManager/index.ts
+++ b/packages/signaldb/src/SyncManager/index.ts
@@ -246,7 +246,7 @@ export default class SyncManager<
     // schedule for next tick to allow other tasks to run first
     await new Promise((resolve) => { setTimeout(resolve, 0) })
     const doSync = async () => {
-      const lastFinishedSync = this.syncOperations.findOne({ collectionName: name, status: 'done' }, { sort: { time: -1 } })
+      const lastFinishedSync = this.syncOperations.findOne({ collectionName: name, status: 'done' }, { sort: { end: -1 } })
       if (options?.onlyWithChanges) {
         const currentChanges = this.changes.find({
           collectionName: name,
@@ -291,7 +291,7 @@ export default class SyncManager<
       status: 'active',
     })
 
-    const lastFinishedSync = this.syncOperations.findOne({ collectionName: name, status: 'done' }, { sort: { time: -1 } })
+    const lastFinishedSync = this.syncOperations.findOne({ collectionName: name, status: 'done' }, { sort: { end: -1 } })
     const lastSnapshot = this.snapshots.findOne({ collectionName: name }, { sort: { time: -1 } })
     const currentChanges = this.changes.find({
       collectionName: name,


### PR DESCRIPTION
Noticed a bug with sync manager where the lastSyncTimestamp is always the same (the first/original one). I think the issue is due to incorrect sorting. Suggested fix in the PR