### PR TITLE
Gimme type protection on queries

### DIFF
--- a/packages/signaldb/src/types/Selector.ts
+++ b/packages/signaldb/src/types/Selector.ts
@@ -39,7 +39,7 @@ type Flatten<T> = T extends any[] ? T[0] : T
 
 type FlatQuery<T> = {
   [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>>
-} & Record<string, any>
+}
 type Query<T> = FlatQuery<T> & {
   $or?: Query<T>[] | undefined,
   $and?: Query<T>[] | undefined,


### PR DESCRIPTION
Or share why we can't have it? Some tradeoff?