### PR TITLE
refactor: replace EventTarget-based emitter with a native implementation

### DIFF
--- a/packages/base/core/CHANGELOG.md
+++ b/packages/base/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Replace EventTarget-based emitter with a native implementation
+
 ## [1.2.2] - 2025-02-03
 
 ### Fixed

--- a/packages/base/core/src/utils/EventEmitter.spec.ts
+++ b/packages/base/core/src/utils/EventEmitter.spec.ts
@@ -103,31 +103,6 @@ describe('EventEmitter', () => {
     expect(goodbyeListener).toHaveBeenCalledTimes(1)
   })
 
-  it('should return true/false from emit() based on preventDefault()', () => {
-    // By default, events are not cancelable, but CustomEvent is by default set to be cancelable = false
-    // If you want to test cancellation logic, you can set "cancelable: true" in the event init
-    // For demonstration, let's do a small patch:
-
-    const mockDispatchEvent = vi.spyOn(emitter, 'dispatchEvent')
-      .mockImplementation((event: Event) => {
-        // We can simulate a cancellation condition here
-        // e.g., some listeners might call evt.preventDefault() if it's cancelable
-        if (event.cancelable) {
-          event.preventDefault()
-          return !event.defaultPrevented // false
-        }
-        // If it's not cancelable, it returns true
-        return true
-      })
-
-    // By default, our CustomEvent in emit() is not specifying "cancelable: true",
-    // so this should return true
-    const result = emitter.emit('hello', 'CancelTest')
-    expect(result).toBe(true)
-
-    mockDispatchEvent.mockRestore()
-  })
-
   it('should return the array of listener functions with listeners()', () => {
     const fn1 = vi.fn()
     const fn2 = vi.fn()


### PR DESCRIPTION
We're looking at using SignalDB in a React Native app, and ran into an issue where `EventTarget` and `CustomEvent` are not present in the React Native runtime. This reworks the event emitter logic to not depend on these web-platform globals, and just natively implement a simple event listener. I was able to almost entirely re-use the existing tracking logic in the emitter class, with some minor changes.