### PR TITLE
export needed types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8820,9 +8820,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
-      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8836,7 +8836,7 @@
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
+        "object.entries": "^1.1.9",
         "object.fromentries": "^2.0.8",
         "object.values": "^1.2.1",
         "prop-types": "^15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "typescript": "5.8.2"
       },
       "devDependencies": {
-        "sass": "^1.83.1"
+        "sass": "^1.86.3"
       }
     },
     "examples/firebase": {
@@ -96,7 +96,7 @@
         "typescript": "5.8.2"
       },
       "devDependencies": {
-        "sass": "^1.83.1"
+        "sass": "^1.86.3"
       }
     },
     "examples/replication-http": {
@@ -119,7 +119,7 @@
         "typescript": "5.8.2"
       },
       "devDependencies": {
-        "sass": "^1.83.1"
+        "sass": "^1.86.3"
       }
     },
     "examples/supabase": {
@@ -143,7 +143,7 @@
         "typescript": "5.8.2"
       },
       "devDependencies": {
-        "sass": "^1.83.1"
+        "sass": "^1.86.3"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -13037,9 +13037,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.86.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.2.tgz",
-      "integrity": "sha512-Rpfn0zAIDqvnSb2DihJTDFjbhqLHu91Wqac9rxontWk7R+2txcPjuujMqu1eeoezh5kAblVCS5EdFdyr0Jmu+w==",
+      "version": "1.86.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.3.tgz",
+      "integrity": "sha512-iGtg8kus4GrsGLRDLRBRHY9dNVA78ZaS7xr01cWnS7PEMQyFtTqBiyCrfpTYTZXRWM94akzckYjh8oADfFNTzw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/base/core/src/types/Selector.ts
+++ b/packages/base/core/src/types/Selector.ts
@@ -66,13 +66,13 @@ export type FieldValue<U> = U extends string
   ? string | RegExp | FieldExpression<string>
   : U | FieldExpression<U>
 
-  export type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
+export type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
   ? never
   : GetType<T, P> extends Array<infer U>
     ? FieldValue<U> | FieldValue<U[]>
     : FieldValue<GetType<T, P>>
 
-    export type Query<T> = FlatQuery<T> & {
+export type Query<T> = FlatQuery<T> & {
   $or?: Query<T>[],
   $and?: Query<T>[],
   $nor?: Query<T>[],

--- a/packages/base/core/src/types/Selector.ts
+++ b/packages/base/core/src/types/Selector.ts
@@ -33,7 +33,7 @@ export interface FieldExpression<T> {
 }
 
 // Recursive type to generate dot-notation keys
-type DotNotation<T> = {
+export type DotNotation<T> = {
   [K in keyof T & string]: T[K] extends Array<infer U>
     // If it's an array, include both the index and the $ wildcard
     ? `${K}` | `${K}.$` | `${K}.${DotNotation<U>}`
@@ -43,7 +43,7 @@ type DotNotation<T> = {
       : `${K}` // Base case: Just return the key
 }[keyof T & string]
 
-type GetType<T, P extends string> =
+export type GetType<T, P extends string> =
   P extends `${infer H}.${infer R}`
     ? H extends keyof T
       ? T[H] extends Array<infer U>
@@ -58,21 +58,21 @@ type GetType<T, P extends string> =
       ? T[P]
       : never
 
-type FlatQuery<T> = {
+export type FlatQuery<T> = {
   [P in DotNotation<T>]?: FlatQueryValue<T, P>
 }
 
-type FieldValue<U> = U extends string
+export type FieldValue<U> = U extends string
   ? string | RegExp | FieldExpression<string>
   : U | FieldExpression<U>
 
-type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
+  export type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
   ? never
   : GetType<T, P> extends Array<infer U>
     ? FieldValue<U> | FieldValue<U[]>
     : FieldValue<GetType<T, P>>
 
-type Query<T> = FlatQuery<T> & {
+    export type Query<T> = FlatQuery<T> & {
   $or?: Query<T>[],
   $and?: Query<T>[],
   $nor?: Query<T>[],

--- a/packages/base/core/src/types/Selector.ts
+++ b/packages/base/core/src/types/Selector.ts
@@ -58,21 +58,21 @@ export type GetType<T, P extends string> =
       ? T[P]
       : never
 
-export type FlatQuery<T> = {
+type FlatQuery<T> = {
   [P in DotNotation<T>]?: FlatQueryValue<T, P>
 }
 
-export type FieldValue<U> = U extends string
+type FieldValue<U> = U extends string
   ? string | RegExp | FieldExpression<string>
   : U | FieldExpression<U>
 
-export type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
+type FlatQueryValue<T, P extends string> = GetType<T, P> extends never
   ? never
   : GetType<T, P> extends Array<infer U>
     ? FieldValue<U> | FieldValue<U[]>
     : FieldValue<GetType<T, P>>
 
-export type Query<T> = FlatQuery<T> & {
+type Query<T> = FlatQuery<T> & {
   $or?: Query<T>[],
   $and?: Query<T>[],
   $nor?: Query<T>[],


### PR DESCRIPTION
~~In my project I need to extend the default collection. There are some util methods that return a modified query, would be nice to use the types from SignalDB directly.~~

~~In addition~~ I figured out that the types `DotNotation` & `GetType` have a 99.9% overlap with types on my side. I'd also like to use the ones from SignalDB here.