### PR TITLE
feat: collection enrichment

### DIFF
--- a/docs/orm/index.md
+++ b/docs/orm/index.md
@@ -175,3 +175,121 @@ class Post extends BaseEntity<PostType> {
   }
 }
 ```
+
+
+## Solving the N+1 Problem with Enrichment
+
+While the instance method approach (like `post.getAuthor()`) is convenient for accessing related data on individual items, it can lead to the "N+1 problem" when dealing with multiple items. If you fetch N posts and then call `getAuthor()` on each, you might end up making N additional database queries (1 query for the posts + N queries for the authors).
+
+To address this, SignalDB offers an `enrichCollection` option in the `Collection` constructor. This allows you to define a function that efficiently pre-loads related data in bulk for a set of items *before* they are returned by a query, significantly reducing the number of database operations.
+
+### How Enrichment Works
+
+The `enrichCollection` function you provide receives two arguments:
+1.  `items`: An array of items that matched the query's filter, *after* sorting and limiting, but *before* being returned.
+2.  `fields`: The `fields` projection object specified in the query options (e.g., `{ name: 1, author: 1 }`).
+
+Inside this function, you can:
+1.  **Check `fields`:** Determine if the related data field (e.g., `author`) was actually requested in the query. This prevents unnecessary fetching.
+2.  **Collect Foreign Keys:** Extract the unique IDs (foreign keys) needed to fetch the related data from the `items` array.
+3.  **Bulk Fetch:** Perform a *single* query on the related collection (e.g., `Users`) to retrieve all necessary related items at once using the collected keys (e.g., using `$in`).
+4.  **Map Data:** Iterate through the original `items` and replace the foreign key with the corresponding fetched related object.
+
+This process happens automatically whenever a query using the relevant `fields` is executed or re-runs due to reactivity.
+
+### Example
+
+Let's redefine our `Posts` and `Users` collections to use enrichment for fetching authors:
+
+```js
+import { Collection, memoryPersistenceAdapter, primitiveReactivityAdapter, effect } from '@signaldb/core' // Assuming adapters are imported
+
+// User Collection (No changes needed here for this example)
+const Users = new Collection({ 
+  name: 'users',
+  reactivity: primitiveReactivityAdapter,
+  persistence: memoryPersistenceAdapter(),
+})
+
+// Populate Users
+Users.insert({ _id: 'user1', name: 'Alice' })
+Users.insert({ _id: 'user2', name: 'Bob' })
+
+
+// Post Collection with Enrichment
+const Posts = new Collection({
+  name: 'posts',
+  reactivity: primitiveReactivityAdapter,
+  persistence: memoryPersistenceAdapter(),
+  // --- Enrichment Function ---
+  enrichCollection: (items, fields) => {
+    // 1. Check if the 'author' field is requested
+    if (fields?.author) {
+      // 2. Collect unique author IDs
+      const authorIds = [...new Set(items.map(item => item.authorId))]
+      // 3. Bulk fetch authors
+      const relatedAuthors = Users.find({ _id: { $in: authorIds } }).fetch()
+      // 4. Map authors back to posts
+      items.forEach((item) => {
+        // Find the corresponding author and replace the ID
+        // Note: We're replacing/adding the 'author' field, not 'authorId'
+        item.author = relatedAuthors.find(author => author._id === item.authorId)
+        // Optionally delete the original ID field if desired
+        // delete item.authorId; 
+      })
+    }
+    // Note: The function modifies 'items' in place.
+  }
+})
+
+// Populate Posts
+Posts.insert({ _id: 'post1', title: 'First Post', authorId: 'user1' })
+Posts.insert({ _id: 'post2', title: 'Second Post', authorId: 'user2' })
+Posts.insert({ _id: 'post3', title: 'Third Post', authorId: 'user1' })
+
+// --- Usage ---
+
+// Query requesting the author field - enrichment runs
+const postsWithAuthors = Posts.find({}, { fields: { title: 1, author: 1 } }).fetch()
+console.log(postsWithAuthors)
+/* Output:
+[
+  { _id: 'post1', title: 'First Post', author: { _id: 'user1', name: 'Alice' } },
+  { _id: 'post2', title: 'Second Post', author: { _id: 'user2', name: 'Bob' } },
+  { _id: 'post3', title: 'Third Post', author: { _id: 'user1', name: 'Alice' } }
+]
+*/
+
+// Query NOT requesting the author field - enrichment is skipped for 'author'
+const postsWithoutAuthors = Posts.find({}, { fields: { title: 1, authorId: 1 } }).fetch()
+console.log(postsWithoutAuthors)
+/* Output:
+[
+  { _id: 'post1', title: 'First Post', authorId: 'user1' },
+  { _id: 'post2', title: 'Second Post', authorId: 'user2' },
+  { _id: 'post3', title: 'Third Post', authorId: 'user1' }
+]
+*/
+```
+### Reactivity
+
+The enrichment process is fully integrated with SignalDB's reactivity system. If the data in the related collection changes (e.g., a user's name is updated), any reactive query that includes the enriched field will automatically re-run and reflect the changes.
+
+```js
+import { effect, Users, Posts } from './your-setup'; // Assuming Users, Posts, effect are set up/imported
+
+effect(() => {
+  // This query requests the enriched 'author' field
+  const posts = Posts.find({ _id: 'post1' }, { fields: { title: 1, author: 1 } }).fetch()
+  console.log('Post 1 Author:', posts[0]?.author?.name)
+})
+
+// Initial output: Post 1 Author: Alice
+
+// Now, update the related user
+Users.updateOne({ _id: 'user1' }, { $set: { name: 'Alice Smith' } })
+
+// The effect will re-run automatically due to the change in Users
+// Updated output: Post 1 Author: Alice Smith
+```
+By using the enrichCollection option, you can efficiently load related data, avoid the N+1 problem, and maintain reactivity, especially when dealing with lists or collections of items. This approach is often more performant than using instance methods for simple relationship loading in bulk scenarios.

--- a/packages/base/core/src/Collection/Cursor.ts
+++ b/packages/base/core/src/Collection/Cursor.ts
@@ -1,5 +1,6 @@
 import sortItems from '../utils/sortItems'
 import project from '../utils/project'
+import enrich from '../utils/enrich.ts'
 import type ReactivityAdapter from '../types/ReactivityAdapter'
 import type { BaseItem, FindOptions, Transform } from './types'
 import type { ObserveCallbacks } from './Observer'
@@ -19,6 +20,7 @@ export function isInReactiveScope(reactivity: ReactivityAdapter | undefined | fa
 export interface CursorOptions<T extends BaseItem, U = T> extends FindOptions<T> {
   transform?: Transform<T, U>,
   bindEvents?: (requery: () => void) => () => void,
+  enrichCollection?: (items: T[], fields: CursorOptions<T, U>['fields']) => T[],
 }
 
 /**
@@ -48,6 +50,7 @@ export default class Cursor<T extends BaseItem, U = T> {
    * @param options.limit - The maximum number of items to return in the result set.
    * @param options.reactive - A reactivity adapter to enable observing changes in the cursor's result set.
    * @param options.fieldTracking - A boolean to enable fine-grained field tracking for reactivity.
+   * @param options.enrichCollection - A function that will be able to solve the n+1 problem
    */
   constructor(
     getItems: () => T[],
@@ -88,12 +91,13 @@ export default class Cursor<T extends BaseItem, U = T> {
 
   private getItems() {
     const items = this.getFilteredItems()
-    const { sort, skip, limit } = this.options
+    const { sort, skip, limit, enrichCollection } = this.options
     const sorted = sort ? sortItems(items, sort) : items
     const skipped = skip ? sorted.slice(skip) : sorted
     const limited = limit ? skipped.slice(0, limit) : skipped
     const idExcluded = this.options.fields && this.options.fields.id === 0
-    return limited.map((item) => {
+    const entries = enrichCollection ? enrich(limited, this.options) : limited
+    return entries.map((item) => {
       if (!this.options.fields) return item
       return {
         ...idExcluded ? {} : { id: item.id },

--- a/packages/base/core/src/Collection/index.ts
+++ b/packages/base/core/src/Collection/index.ts
@@ -15,6 +15,7 @@ import type { Changeset, LoadResponse } from '../types/PersistenceAdapter'
 import serializeValue from '../utils/serializeValue'
 import type Signal from '../types/Signal'
 import createSignal from '../utils/createSignal'
+import type { CursorOptions } from './Cursor'
 import Cursor from './Cursor'
 import type { BaseItem, FindOptions, Transform } from './types'
 import getIndexInfo from './getIndexInfo'
@@ -34,6 +35,7 @@ export interface CollectionOptions<T extends BaseItem<I>, I, U = T> {
   indices?: IndexProvider<T, I>[],
   enableDebugMode?: boolean,
   fieldTracking?: boolean,
+  enrichCollection?: (collection: T[], fields: CursorOptions<T>['fields']) => void,
 }
 
 interface CollectionEvents<T extends BaseItem, U = T> {
@@ -225,6 +227,7 @@ export default class Collection<
    * @param options.indices - An array of index providers for optimized querying.
    * @param options.enableDebugMode - A boolean to enable or disable debug mode.
    * @param options.fieldTracking - A boolean to enable or disable field tracking by default.
+   * @param options.enrichCollection - A function that will be able to solve the n+1 problem
    */
   constructor(options?: CollectionOptions<T, I, U>) {
     super()
@@ -637,6 +640,7 @@ export default class Collection<
     const cursor = new Cursor<T, U>(() => this.getItems(selector), {
       reactive: this.options.reactivity,
       fieldTracking: this.fieldTracking,
+      enrichCollection: this.options.enrichCollection,
       ...options,
       transform: this.transform.bind(this),
       bindEvents: (requery) => {

--- a/packages/base/core/src/utils/enrich.spec.ts
+++ b/packages/base/core/src/utils/enrich.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import enrich from './enrich'
+
+describe('enrich', () => {
+  const parents = [{
+    id: '1',
+    name: 'John Doe Sr.',
+  }]
+  const objects = [{
+    name: 'John Doe',
+    age: 25,
+    parent: '1',
+  }]
+
+  it('should enrich with a parent', () => {
+    const result = enrich(objects, {
+      fields: {
+        name: 1,
+        age: 1,
+        parent: 1,
+      },
+      enrichCollection: (items, fields) => {
+        if (fields?.parent) {
+          return items.map((item) => {
+            item.parent = parents.find(parent => parent.id === item.parent)
+          })
+        }
+      },
+    })
+
+    expect(result).toEqual([{
+      name: 'John Doe',
+      age: 25,
+      parent: {
+        id: '1',
+        name: 'John Doe Sr.',
+      },
+    }])
+  })
+})

--- a/packages/base/core/src/utils/enrich.ts
+++ b/packages/base/core/src/utils/enrich.ts
@@ -1,0 +1,25 @@
+import type { CursorOptions } from '../Collection'
+import { clone } from './deepClone.ts'
+
+/**
+ * Enrich a collection based on a specified fields configuration.
+ * @template T - The type of the items in the collection.
+ * @param items - The collection to enrich.
+ * @param options - Optional configuration for the cursor.
+ * @param options.fields - An object defining the fields to include (`1`) or exclude (`0`).
+ *   - Keys are the field names, and values are either `1` (include) or `0` (exclude).
+ * @param options.enrichCollection - A function that will be able to solve the n+1 problem
+ * @returns A new collection with the specified fields included.
+ */
+export default function enrich<T extends Record<string, any>>(
+  items: T[],
+  options: CursorOptions<T>,
+) {
+  if (!options.enrichCollection || !options.fields) {
+    return items
+  }
+
+  const result = clone(items)
+  options.enrichCollection(result, options.fields)
+  return result
+}


### PR DESCRIPTION
Solution to the "N+1 problem" when dealing with related data. By implementing the enrichCollection option within the Collection definition you can reduce the number of queries required.

changes:
- Introduces the enrichCollection option in the collection
- Created tests
- Created benchmark

