### PR TITLE
fix(sync): Ensure scheduled pushes are handled sequentially

### DIFF
--- a/packages/base/sync/src/SyncManager.ts
+++ b/packages/base/sync/src/SyncManager.ts
@@ -329,11 +329,11 @@ export default class SyncManager<
     }
   }
 
-  protected flushScheduledPushes() {
-    this.scheduledPushes.forEach((name) => {
-      this.pushChanges(name).catch(() => { /* error handler is called in sync */ })
-    })
-    this.scheduledPushes.clear()
+  protected async flushScheduledPushes() {
+    for (const name of this.scheduledPushes) {
+      await this.pushChanges(name).catch(() => { /* error handler is called in sync */ });
+    }
+    this.scheduledPushes.clear();
   }
 
   protected schedulePush(name: string) {

--- a/packages/base/sync/src/SyncManager.ts
+++ b/packages/base/sync/src/SyncManager.ts
@@ -164,7 +164,7 @@ export default class SyncManager<
     this.snapshots.setMaxListeners(1000)
     this.syncOperations.setMaxListeners(1000)
 
-    this.debouncedFlush = debounce(this.flushScheduledPushes, this.options.debounceTime ?? 100)
+    this.debouncedFlush = debounce(() => void this.flushScheduledPushes(), this.options.debounceTime ?? 100)
   }
 
   protected createPersistenceAdapter(name: string) {
@@ -331,9 +331,9 @@ export default class SyncManager<
 
   protected async flushScheduledPushes() {
     for (const name of this.scheduledPushes) {
-      await this.pushChanges(name).catch(() => { /* error handler is called in sync */ });
+      await this.pushChanges(name).catch(() => { /* error handler is called in sync */ })
     }
-    this.scheduledPushes.clear();
+    this.scheduledPushes.clear()
   }
 
   protected schedulePush(name: string) {


### PR DESCRIPTION
I was running into issues with foreign key constraints because pushes were not done in the correct order.

For example: Let's say you want to create a new `Team` and also immediately insert 3 `Members`. In the client you would insert the team to the collection, and then insert the members (each linked to the team id) into their own collection. That would schedule a push for each collection.

So far so good. But since the sync happens in parallel it's possible that the backend tries to add members before the team is created in the database leading to a failed sync.