### PR TITLE
Add dot notation support to Modifier type

### DIFF
--- a/packages/base/core/CHANGELOG.md
+++ b/packages/base/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Type safety for modifiers in `updateOne`, `updateMany`, and `replaceOne` methods
+
 ### Fixed
 
 * Fixed a bug where nested array parts where not resolved correctly

--- a/packages/base/core/src/types/Modifier.spec.ts
+++ b/packages/base/core/src/types/Modifier.spec.ts
@@ -1,0 +1,55 @@
+import { it, expectTypeOf } from 'vitest'
+import type Modifier from './Modifier'
+
+interface TestUser {
+  name: string,
+  age: number,
+  tags: string[],
+  address: {
+    street: string,
+    city: string,
+  },
+  scores: {
+    math: number,
+    science: number,
+    deep: {
+      nested: boolean,
+    },
+  }[],
+  deep: {
+    nested: {
+      value: boolean,
+    },
+  },
+}
+
+it('should allow dot notation in $set', () => {
+  expectTypeOf<Modifier<TestUser>>().toExtend<{
+    $set?: {
+      'address.street'?: string,
+      'deep.nested.value'?: boolean,
+      'scores.$.math'?: number,
+    },
+    $inc?: {
+      age?: number,
+    },
+  }>()
+})
+
+it('should allow array modifications', () => {
+  expectTypeOf<Modifier<TestUser>>().toExtend<{
+    $push?: {
+      'tags'?: string | { $each?: string[] | undefined },
+      'scores.$.math'?: number | { $each?: number[] | undefined },
+    },
+    $pushAll?: {
+      scores?: {
+        math?: number,
+        science?: number,
+        deep?: {
+          nested?: boolean,
+        },
+      },
+    },
+  }>()
+})

--- a/packages/base/core/src/types/Modifier.ts
+++ b/packages/base/core/src/types/Modifier.ts
@@ -1,43 +1,45 @@
 // borrowed from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/meteor/mongo.d.ts
 
+import type { DotNotation, GetType } from './Selector'
+
 type Dictionary<T> = Record<string, T>
-type PartialMapTo<T, M> = Partial<Record<keyof T, M>>
+type PartialMapTo<T, M> = Partial<Record<DotNotation<T>, M>> & Dictionary<M>
 type OnlyElementsOfArrays<T> = T extends any[] ? Partial<T[0]> : never
 type ElementsOf<T> = {
-  [P in keyof T]?: OnlyElementsOfArrays<T[P]>
+  [P in DotNotation<T>]?: OnlyElementsOfArrays<GetType<T, P>>
 }
 type PushModifier<T> = {
-  [P in keyof T]?:
-    | OnlyElementsOfArrays<T[P]>
+  [P in DotNotation<T>]?:
+    | OnlyElementsOfArrays<GetType<T, P>>
     | {
-      $each?: T[P] | undefined,
+      $each?: GetType<T, P> | undefined,
       $position?: number | undefined,
       $slice?: number | undefined,
       $sort?: 1 | -1 | Dictionary<number> | undefined,
     }
 }
 type ArraysOrEach<T> = {
-  [P in keyof T]?: OnlyElementsOfArrays<T[P]> | { $each: T[P] }
+  [P in DotNotation<T>]?: OnlyElementsOfArrays<GetType<T, P>> | { $each: GetType<T, P> }
 }
 type CurrentDateModifier = { $type: 'timestamp' | 'date' } | true
 
 type Modifier<T extends Dictionary<any> = Dictionary<any>>
   = | {
     $currentDate?:
-    | (Partial<Record<keyof T, CurrentDateModifier>> & Dictionary<CurrentDateModifier>)
+    | (Partial<Record<DotNotation<T>, CurrentDateModifier>> & Dictionary<CurrentDateModifier>)
     | undefined,
     $inc?: (PartialMapTo<T, number> & Dictionary<number>) | undefined,
     $min?: (PartialMapTo<T, Date | number> & Dictionary<Date | number>) | undefined,
     $max?: (PartialMapTo<T, Date | number> & Dictionary<Date | number>) | undefined,
     $mul?: (PartialMapTo<T, number> & Dictionary<number>) | undefined,
     $rename?: (PartialMapTo<T, string> & Dictionary<string>) | undefined,
-    $set?: (Partial<T> & Dictionary<any>) | undefined,
-    $setOnInsert?: (Partial<T> & Dictionary<any>) | undefined,
+    $set?: ({ [P in DotNotation<T>]?: GetType<T, P> } & Dictionary<any>) | undefined,
+    $setOnInsert?: ({ [P in DotNotation<T>]?: GetType<T, P> } & Dictionary<any>) | undefined,
     $unset?: (PartialMapTo<T, string | boolean | 1 | 0> & Dictionary<any>) | undefined,
     $addToSet?: (ArraysOrEach<T> & Dictionary<any>) | undefined,
     $push?: (PushModifier<T> & Dictionary<any>) | undefined,
     $pull?: (ElementsOf<T> & Dictionary<any>) | undefined,
-    $pullAll?: (Partial<T> & Dictionary<any>) | undefined,
+    $pullAll?: ({ [P in DotNotation<T>]?: GetType<T, P> } & Dictionary<any>) | undefined,
     $pop?: (PartialMapTo<T, 1 | -1> & Dictionary<1 | -1>) | undefined,
   }
 


### PR DESCRIPTION
## Summary
- extend `Modifier` to check fields using dot notation
- add tests for Modifier dot notation type checking

## Testing
- `npm exec vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ce50403a88326b98a729c6fb0ae0f