### PR TITLE
fix: change AsyncDataAdapter setup order and remove duplicate check

### DIFF
--- a/packages/base/core/src/AsyncDataAdapter.ts
+++ b/packages/base/core/src/AsyncDataAdapter.ts
@@ -203,8 +203,8 @@ export default class AsyncDataAdapter implements DataAdapter {
     const storage = this.storageAdapters.get(collectionName)
     if (!storage) throw new Error(`No persistence adapter for collection ${collectionName}`)
 
-    await Promise.all(indices.map(index => storage.createIndex(index)))
     await storage.setup()
+    await Promise.all(indices.map(index => storage.createIndex(index)))
   }
 
   private ensureStorageAdapter(name: string) {
@@ -431,14 +431,8 @@ export default class AsyncDataAdapter implements DataAdapter {
   ): Promise<T> {
     const storage = this.storageAdapters.get(collectionName)
     if (!storage) throw new Error(`No persistence adapter for collection ${collectionName}`)
-
-    const existing = await this.executeQuery<T, I>(
-      collectionName,
-      { id: newItem.id } as Selector<T>,
-      { limit: 1 },
-    )
-    if (existing.length > 0) throw new Error(`Item with id ${String(newItem.id)} already exists`)
-
+    
+    // Storage handles duplicates according to its semantics
     await storage.insert([newItem])
     await this.checkQueryUpdates(collectionName, [newItem])
     return newItem


### PR DESCRIPTION
### 1. Wrong order in `setupStorage()`
Currently, `AsyncDataAdapter.setupStorage()` creates indexes before calling `setup()`, causing **"no such table"** errors because indexes are created before tables exist.

### 2. Duplicate check prevents upsert
`AsyncDataAdapter.insert()` checks for existing items before calling `storage.insert()`. SyncManager intentionally calls `insert()` multiple times during sync (pull + snapshot).

**Error:** `Item with id X already exists` during `Collection.replaceOne(..., { upsert: true })`