### PR TITLE
fix: wrap remote change handling in sync queue

### DIFF
--- a/packages/base/sync/src/SyncManager.ts
+++ b/packages/base/sync/src/SyncManager.ts
@@ -347,10 +347,9 @@ export default class SyncManager<
       ? await this.options.registerRemoteChange(
         collectionParameters.options,
         async (data) => {
-          if (data == null) {
-            await this.sync(name)
-          } else {
-            await this.getSyncQueue(name).add(async () => {
+          await (data == null
+            ? this.sync(name)
+            : this.getSyncQueue(name).add(async () => {
               const syncTime = Date.now()
               const syncId = await this.syncOperations.insert({
                 start: syncTime,
@@ -384,8 +383,7 @@ export default class SyncManager<
                   })
                   throw error
                 })
-            })
-          }
+            }))
         },
       )
       : undefined


### PR DESCRIPTION
resolves #2465 
Fixed a race condition in `SyncManager` by wrapping the `registerRemoteChange` callback execution in the synchronization queue to ensure sequential access to the sync-operations collection.