### PR TITLE
fix: remote change reactivity

### DIFF
--- a/packages/base/core/src/Collection/Observer.ts
+++ b/packages/base/core/src/Collection/Observer.ts
@@ -188,10 +188,15 @@ export default class Observer<T extends { id: any }> {
     })
   }
 
+  private stopped = false
+
   /**
    * Stops the observer by unbinding all events and cleaning up resources.
+   * Safe to call multiple times - will only unbind once.
    */
   public stop() {
+    if (this.stopped) return
+    this.stopped = true
     this.unbindEvents()
   }
 


### PR DESCRIPTION
resolves #2479

1. Added a stopped flag to `Observer` class to prevent multiple `stop()` calls from having side effects
2. Added `didRegister` tracking in `Collection.find()` to ensure only the observer that originally registered the query can unregister it
3. Changed `setTimeout` to `queueMicrotask` for more predictable timing