### PR TITLE
fix(core): guard unsafe regex selectors

### DIFF
--- a/packages/base/core/CHANGELOG.md
+++ b/packages/base/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Reject unsafe `$regex` selector patterns before passing queries to mingo.
+
 ## [1.8.1] - 2026-03-17
 
 ### Fixed

--- a/packages/base/core/src/utils/match.spec.ts
+++ b/packages/base/core/src/utils/match.spec.ts
@@ -61,4 +61,36 @@ describe('match', () => {
     expect(match({ name: undefined as null | undefined }, { name: { $ne: null } })).toBe(false)
     expect(match({ name: undefined as null | undefined }, { name: null })).toBe(true)
   })
+
+  it('should match safe regex selectors', () => {
+    expect(match({ name: 'John' }, { name: { $regex: 'Jo' } })).toBe(true)
+    expect(match({ name: 'John' }, { name: /oh/ })).toBe(true)
+  })
+
+  it('should reject unsafe regex selectors before mingo evaluates them', () => {
+    expect(() => match({ name: 'a'.repeat(28) + '!' }, {
+      name: { $regex: '^(a+)+$' },
+    })).toThrow('Unsafe $regex pattern rejected')
+  })
+
+  it('should reject unsafe regex selectors nested in logical operators', () => {
+    expect(() => match({ name: 'a'.repeat(28) + '!' }, {
+      $or: [
+        { name: 'John' },
+        { name: { $regex: /^(a+)+$/ } },
+      ],
+    })).toThrow('Unsafe $regex pattern rejected')
+  })
+
+  it('should reject unsafe direct regex selector values', () => {
+    expect(() => match({ name: 'a'.repeat(28) + '!' }, {
+      name: /^(a+)+$/,
+    })).toThrow('Unsafe $regex pattern rejected')
+  })
+
+  it('should reject regex selectors over the maximum length', () => {
+    expect(() => match({ name: 'John' }, {
+      name: { $regex: 'a'.repeat(513) },
+    })).toThrow('Unsafe $regex pattern rejected')
+  })
 })

--- a/packages/base/core/src/utils/match.ts
+++ b/packages/base/core/src/utils/match.ts
@@ -3,6 +3,48 @@ import type Selector from '../types/Selector'
 
 type BaseItem = Record<string, any>
 
+const maxRegexSourceLength = 512
+const quantifier = String.raw`(?:[*+?]|\{\d+(?:,\d*)?\})`
+const groupChunk = String.raw`(?:\\.|[^\\()[\]])`
+const nestedQuantifierPattern = new RegExp(
+  String.raw`\(${groupChunk}*${quantifier}${groupChunk}*\)${quantifier}`,
+)
+
+/**
+ * Throws when a regex pattern is likely unsafe to evaluate against user data.
+ */
+function assertSafeRegex(pattern: RegExp | string) {
+  const source = typeof pattern === 'string' ? pattern : pattern.source
+  if (source.length > maxRegexSourceLength || nestedQuantifierPattern.test(source)) {
+    throw new TypeError(`Unsafe $regex pattern rejected: ${source}`)
+  }
+}
+
+/**
+ * Walks a selector tree and validates every regex value before mingo sees it.
+ */
+function assertSafeRegexSelectors(value: unknown) {
+  if (value instanceof RegExp) {
+    assertSafeRegex(value)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(assertSafeRegexSelectors)
+    return
+  }
+
+  if (value == null || typeof value !== 'object') return
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === '$regex' && (typeof nestedValue === 'string' || nestedValue instanceof RegExp)) {
+      assertSafeRegex(nestedValue)
+      continue
+    }
+    assertSafeRegexSelectors(nestedValue)
+  }
+}
+
 /**
  * Tests whether a given item matches a specified selector.
  * Uses the `mingo` library to evaluate the query.
@@ -15,6 +57,7 @@ export default function match<T extends BaseItem = BaseItem>(
   item: T,
   selector: Selector<T>,
 ) {
+  assertSafeRegexSelectors(selector)
   const query = new Query(selector)
   return query.test(item)
 }


### PR DESCRIPTION
## Summary

Adds a narrow guard before `match()` hands selectors to mingo so unsafe regex patterns are rejected at the SignalDB selector boundary.

The guard:

* walks nested selectors recursively, including logical operators such as `$or`
* rejects nested quantified regex shapes such as `^(a+)+$` before mingo evaluates them
* also checks direct `RegExp` selector values
* preserves normal safe `$regex` strings and `RegExp` selector matching

## Why

SignalDB accepts application-provided selectors and currently passes regex selector input directly into mingo. Keeping the check here prevents app-facing selector input from reaching regex evaluation when it has a known unsafe structure.

## Validation

* `npm test -- --run packages/base/core/src/utils/match.spec.ts`
* `npm run type-check -- --pretty false`
* `npm run coverage -- --run packages/base/core/src/utils/match.spec.ts --coverage.reporter=text` (100% statements/branches/functions/lines for `match.ts`)
* `git diff --check`

Note: I also tried `npx eslint packages/base/core/src/utils/match.ts packages/base/core/src/utils/match.spec.ts`, but ESLint exits before reading these files because `eslint.config.mjs` imports `@eslint/js` and that package is not installed from the current package metadata in this checkout.
